### PR TITLE
feat: ignore not instant payment method- ATM(自動櫃員機) CVS(超商代碼) BARCODE(超商條碼) BNPL(裕富無卡分期)

### DIFF
--- a/src/services/handleECpay.ts
+++ b/src/services/handleECpay.ts
@@ -10,14 +10,7 @@ export const options = {
     HashKey: HASHKEY,
     HashIV: HASHIV
   },
-  IgnorePayment: [
-    //    "Credit",
-    //    "WebATM",
-    //    "ATM",
-    //    "CVS",
-    //    "BARCODE",
-    //    "AndroidPay"
-  ],
+  IgnorePayment: 'ATM#CVS#BARCODE#BNPL',
   IsProjectContractor: false
 };
 


### PR DESCRIPTION
目前APP只接受立即付款，因此隱藏非立即付款的繳費方式：ATM(自動櫃員機) CVS(超商代碼) BARCODE(超商條碼) BNPL(裕富無卡分期)
setting ref: https://developers.ecpay.com.tw/?p=2864#ChoosePayment